### PR TITLE
docs: add agent instructions

### DIFF
--- a/.github/AGENTS.md
+++ b/.github/AGENTS.md
@@ -1,0 +1,25 @@
+# GitHub Workflow Instructions
+
+This directory contains release automation, not general CI. Keep workflow edits conservative and do not change release behavior unless the user explicitly asks.
+
+## Current Workflows
+
+- `android-release.yml`: manual city Android release to Google Play internal track.
+- `festival-android-release.yml`: manual festival Android release to Google Play internal track.
+- `ios-release.yml`: manual city iOS release to TestFlight/App Store Connect.
+- `festival-ios-release.yml`: manual festival iOS release, optional screenshot update, release-note generation, and App Store Connect upload.
+
+## Rules
+
+- Preserve `workflow_dispatch` inputs unless the requested change is specifically about release triggering.
+- Do not add automatic `push` or tag triggers to release workflows without explicit approval.
+- Do not weaken secret handling, signing setup, version bumping, tagging, or upload steps.
+- Do not run `gh workflow run`, release fastlane lanes, Google Play uploads, App Store Connect uploads, or signing steps without explicit approval.
+- If editing generated commit messages in workflows, prefer Conventional Commits for new messages. Existing release-bot messages may not follow that format; do not churn them unless asked.
+- For macOS runner or Xcode changes, preserve comments explaining current pins unless you have verified the replacement on the current date.
+
+## Validation
+
+- For workflow-only edits, validate YAML shape with local inspection where possible.
+- If GitHub CLI checks are requested, use read-only commands first, such as `gh workflow list`, `gh run list`, or `gh run view`.
+- For release workflow changes, explain which secrets and external services are affected; do not print secret values.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,59 @@
+# Agent Instructions
+
+These instructions are for AI coding agents working in this repository. Keep them operational: prefer concrete commands, preserve existing user changes, and avoid expanding the scope into contributor documentation.
+
+## Required Practices
+
+- Use Conventional Commits for any commit you create. Follow https://www.conventionalcommits.org, for example `docs: add agent instructions`.
+- Treat the worktree as user-owned. This repository often has unrelated local edits; do not revert, reformat, or clean files you were not asked to touch.
+- Use `rg` and `rg --files` for searching when available.
+- Keep changes scoped to the requested surface. Do not update READMEs, generated outputs, release metadata, screenshots, or IDE files unless the user explicitly asks.
+- Do not read, print, edit, or regenerate secrets unless explicitly requested: `.env`, `local.properties`, `keystore.properties`, `play_config.json`, `GoogleService-Info.plist`, `google-services.json`, ASC keys, signing profiles, and keystores.
+- Do not run release, deploy, signing, upload, App Store Connect, Google Play, screenshot-upload, or version-bump workflows without explicit user approval.
+
+## Project Map
+
+- Android Gradle root: `settings.gradle.kts` currently includes `:moers-android`, `:moers-festival-android`, and `:modules:*`.
+- Android feature modules live under `modules/`.
+- City Android app lives under `moers-android` with package `com.lambdadigamma.moers`.
+- Festival Android app lives under `moers-festival-android` with package `com.lambdadigamma.moersfestival`.
+- City iOS app lives under `ios/Moers.xcodeproj`.
+- Festival iOS app lives under `ios/moers festival`.
+- Reusable Swift package lives under `ios/CityOS`.
+- Marketing and App Store screenshot tooling lives under `marketing`.
+- `composeApp` and `shared` exist in the repository, but they are not included in the current root `settings.gradle.kts`. Verify the current Gradle settings before treating them as active build targets.
+
+## Common Commands
+
+Run commands from the repository root unless a nested `AGENTS.md` says otherwise.
+
+- Inspect Gradle projects: `./gradlew projects`
+- Build city Android debug: `./gradlew :moers-android:assembleDebug`
+- Test city Android debug unit tests: `./gradlew :moers-android:testDebugUnitTest`
+- Build festival Android debug: `./gradlew :moers-festival-android:assembleDebug`
+- Test festival Android debug unit tests: `./gradlew :moers-festival-android:testDebugUnitTest`
+- Test an Android module: `./gradlew :modules:<module>:testDebugUnitTest`
+- Test CityOS Swift package: `swift test --package-path ios/CityOS`
+- Build city iOS app: `xcodebuild -project ios/Moers.xcodeproj -scheme Moers -configuration "Debug (Production)" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`
+- Build festival iOS app: `xcodebuild -project "ios/moers festival/moers festival.xcodeproj" -scheme "moers festival" -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`
+- Marketing lint/typecheck: `cd marketing && npm run lint`
+- Marketing Storybook: `cd marketing && npm run storybook`
+- Marketing screenshot export: `cd marketing && npm run export:all`
+
+If a command fails because it needs normal Xcode, SwiftPM, Gradle, npm, or simulator caches outside the sandbox, ask for escalation instead of inventing a workaround.
+
+## Validation Policy
+
+- Use targeted checks for the files you touched. Prefer the narrowest module/app test or build that proves the change.
+- For UI or runtime behavior changes, build/install with the platform tooling first, then evaluate with Mobile MCP.
+- With Mobile MCP, list devices dynamically, choose an appropriate currently available simulator/emulator, launch by package or bundle ID, and capture screenshots. Do not hard-code device IDs from a previous session.
+- For documentation-only changes, read the changed files back and verify the expected file list; an app build is not required.
+
+## Release References
+
+These are references only. Do not run them without explicit approval.
+
+- Android release workflows: `.github/workflows/android-release.yml`, `.github/workflows/festival-android-release.yml`.
+- iOS release workflows: `.github/workflows/ios-release.yml`, `.github/workflows/festival-ios-release.yml`.
+- Android fastlane lanes live under `moers-android/fastlane` and `moers-festival-android/fastlane`.
+- iOS fastlane lanes live under `ios/fastlane` and `ios/moers festival/fastlane`.

--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -1,0 +1,50 @@
+# iOS Instructions
+
+This subtree contains the city iOS app, the festival iOS app, shared test plans, fastlane release automation, and the local `CityOS` Swift package.
+
+## Project Map
+
+- City app project: `ios/Moers.xcodeproj`
+- City app bundle ID: `de.okfn.niederrhein.Moers`
+- City app schemes include `Moers`, `Screenshots`, `Onboarding`, `WidgetsExtension`, and `Intent Extensions`.
+- City app build configurations are `Debug (Production)` and `Release (Production)`.
+- Festival app project: `ios/moers festival/moers festival.xcodeproj`
+- Reusable Swift package: `ios/CityOS`
+- Shared test plans live under `ios/Test Plans`.
+- SwiftLint config: `ios/.swiftlint.yml`.
+
+## Local Configuration
+
+- Do not read or edit Google service plists, Tankerkoenig plists, ASC keys, signing profiles, or fastlane `.env` files unless explicitly requested.
+- Xcode and SwiftPM commands may update package resolution files. Do not keep `Package.resolved` changes unless dependency resolution is the requested work.
+- If Xcode needs simulator, SwiftPM, or DerivedData cache access outside the sandbox, ask for escalation instead of changing package paths or project settings.
+
+## City App Commands
+
+- Build city app:
+  `xcodebuild -project ios/Moers.xcodeproj -scheme Moers -configuration "Debug (Production)" -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`
+- Test city app with the full test plan:
+  `xcodebuild -project ios/Moers.xcodeproj -scheme Moers -testPlan FullTestPlan -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test`
+- Test CityOS package:
+  `swift test --package-path ios/CityOS`
+- Run fastlane from `ios` only when explicitly requested:
+  `cd ios && bundle exec fastlane ios <lane>`
+
+For UI/runtime changes:
+
+1. Build with Xcode tooling.
+2. Use Mobile MCP to list devices dynamically.
+3. Launch `de.okfn.niederrhein.Moers`.
+4. Capture screenshots for the affected flow.
+
+## Style And Testing
+
+- Keep UIKit, SwiftUI, and package code in the style already used by nearby files.
+- Respect `@MainActor` boundaries in UI controllers and view models.
+- Prefer existing Factory container registration patterns for dependency injection.
+- Use XCTest patterns already present in the relevant target.
+- Run SwiftLint if you changed enough Swift code that style risk is meaningful.
+
+## Release References
+
+Fastlane lanes under `ios/fastlane` include version bumping, build/upload, metadata, screenshots, release, and signing lanes. Do not run upload, release, signing, screenshot upload, App Store Connect, or version-bump lanes without explicit approval.

--- a/ios/CityOS/AGENTS.md
+++ b/ios/CityOS/AGENTS.md
@@ -1,0 +1,34 @@
+# CityOS Swift Package Instructions
+
+`CityOS` is a local Swift package used by the iOS apps.
+
+## Package Facts
+
+- Manifest: `ios/CityOS/Package.swift`
+- Swift tools version: 6.2
+- Platforms: iOS 16, macOS 12, watchOS 7, tvOS 14
+- Core products include `Core`, `CoreCache`, `DashboardFeature`, `RubbishFeature`, `ParkingFeature`, `NewsFeature`, `FuelFeature`, `MapFeature`, `MMEvents`, `MMPages`, `MMFeeds`, `EFAAPI`, `EFAUI`, `PlaybackKit`, and `AppUpdateFeature`.
+- The package enables upcoming Swift features in shared `swiftSettings`; do not remove these settings without a targeted migration reason.
+
+## Coding Patterns
+
+- Keep resources under each target's `Resources` directory and access package resources with `Bundle.module`.
+- Use Factory registration patterns already present in target code.
+- Keep async service and repository APIs consistent with nearby code; do not mix callback and async styles unless the existing API requires it.
+- Preserve `@MainActor` on UI-facing view models and controllers.
+- When touching database-backed packages such as `MMEvents`, `MMPages`, or `MMFeeds`, add focused tests around records, stores, repositories, or mappers.
+
+## Commands
+
+- Build package: `swift build --package-path ios/CityOS`
+- Test package: `swift test --package-path ios/CityOS`
+- Test one suite: `swift test --package-path ios/CityOS --filter MMEventsTests`
+- Describe package targets: `swift package describe --package-path ios/CityOS`
+
+If SwiftPM needs normal user cache access and the sandbox blocks it, ask for escalation.
+
+## Do Not
+
+- Do not update dependencies or `Package.resolved` unless dependency work is explicitly requested.
+- Do not move package targets or products without checking the iOS app project references.
+- Do not add app-specific secrets or bundle-specific configuration to the package.

--- a/ios/moers festival/AGENTS.md
+++ b/ios/moers festival/AGENTS.md
@@ -1,0 +1,45 @@
+# Moers Festival iOS Instructions
+
+This subtree contains the festival iOS, widget, watchOS, and tvOS project.
+
+## App Facts
+
+- Project: `ios/moers festival/moers festival.xcodeproj`
+- Main app bundle ID: `de.okfn.niederrhein.moers-festival`
+- Main scheme: `moers festival`
+- Other schemes include `moers festival (Widgets)`, `moers festival tvOS`, `moers festival Watch App`, `WidgetsExtension`, and CityOS package schemes exposed through Xcode.
+- Build configurations are `Debug` and `Release`.
+- Main app source lives under `ios/moers festival/moers festival`.
+- Widgets live under `ios/moers festival/Widgets`.
+
+## Commands
+
+- Build main app:
+  `xcodebuild -project "ios/moers festival/moers festival.xcodeproj" -scheme "moers festival" -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`
+- Test main app:
+  `xcodebuild -project "ios/moers festival/moers festival.xcodeproj" -scheme "moers festival" -testPlan TestPlan -destination 'platform=iOS Simulator,name=iPhone 17 Pro' test`
+- Build widget scheme:
+  `xcodebuild -project "ios/moers festival/moers festival.xcodeproj" -scheme "moers festival (Widgets)" -configuration Debug -destination 'platform=iOS Simulator,name=iPhone 17 Pro' build`
+- Run fastlane only when explicitly requested:
+  `cd "ios/moers festival" && bundle exec fastlane ios <lane>`
+
+For UI/runtime changes:
+
+1. Build with Xcode tooling.
+2. Use Mobile MCP to list devices dynamically.
+3. Launch `de.okfn.niederrhein.moers-festival`.
+4. Capture screenshots for the affected flow and relevant device class.
+
+## Architecture Notes
+
+- The project mixes UIKit, SwiftUI, WidgetKit, and the local `CityOS` package.
+- Use existing coordinator/controller patterns for app navigation.
+- Use Factory container registrations where nearby code already does.
+- Keep widget data sync behavior consistent with shared widget support code.
+- Festival screenshots are connected to the marketing Remotion project; do not update raw screenshots, processed stills, or App Store screenshot assets unless that is the requested task.
+
+## Release And Screenshot References
+
+Fastlane lanes include `load_asc_api_key`, `register_dev_devices`, `match_appstore`, `match_development`, `signing`, `increment_build`, `increment_version`, `build_release`, `upload_testflight`, `upload_release_notes`, `ensure_app_version`, `upload`, `release`, `capture`, `render_stills`, `replace_screenshots`, `upload_screenshots`, `screenshots_pipeline`, and tvOS release lanes.
+
+Do not run signing, match, version bump, upload, release, App Store Connect, screenshot upload, or `screenshots_pipeline` lanes without explicit approval.

--- a/marketing/AGENTS.md
+++ b/marketing/AGENTS.md
@@ -1,0 +1,44 @@
+# Marketing And Remotion Instructions
+
+This subtree contains the Remotion/React project used for App Store marketing and screenshot stills.
+
+## Project Facts
+
+- Package root: `marketing`
+- Main Remotion root: `marketing/src/Root.tsx`
+- Components live under `marketing/src/components`.
+- Screenshot sizes and device mappings live in `marketing/src/apple-screenshot-sizes.ts` and `marketing/src/screenshot-collections.ts`.
+- Localized marketing copy lives in `marketing/src/i18n/translations.ts`.
+- Public assets live under `marketing/public`.
+- Generated outputs include `marketing/out`, `marketing/dist`, and `marketing/storybook-static`; do not edit generated output by hand.
+
+## Commands
+
+- Install dependencies when needed: `npm install`
+- Remotion studio: `npm run dev`
+- Lint and typecheck: `npm run lint`
+- Storybook: `npm run storybook`
+- Build Storybook: `npm run build-storybook`
+- Render default still: `npm run render`
+- Export German stills: `npm run export:de`
+- Export English stills: `npm run export:en`
+- Export all stills: `npm run export:all`
+- Start image server: `npm run server`
+
+Some scripts call `bun` internally. Use the package scripts instead of rewriting the script commands unless the task is specifically about script maintenance.
+
+## Remotion Patterns
+
+- Define stills in `Root.tsx` using stable component references.
+- Keep screenshot dimensions tied to the Apple screenshot size registry.
+- Use existing screenshot context components instead of ad hoc layout globals.
+- Use `staticFile()` for public assets and keep paths relative to `marketing/public`.
+- Keep locale handling restricted to supported locales unless the task includes localization expansion.
+- For text changes, update both `de-DE` and `en-US` translations when applicable.
+
+## Validation
+
+- Run `npm run lint` for TypeScript or React changes.
+- For visual changes, run Storybook or Remotion Studio and inspect the affected compositions.
+- For export pipeline changes, run the narrowest relevant export command before `export:all`.
+- Do not upload screenshots or sync App Store assets from this directory unless explicitly requested.

--- a/modules/AGENTS.md
+++ b/modules/AGENTS.md
@@ -1,0 +1,38 @@
+# Android Module Instructions
+
+This subtree contains Android and Kotlin feature modules shared by the app modules. Follow the local module style instead of normalizing the whole tree.
+
+## Structure
+
+- Festival-era modules usually use `data`, `domain`, and `presentation` packages.
+- Older city modules may use feature-specific packages such as `dashboard`, `detail`, `list`, `source`, or `ui`.
+- `modules/core` is Kotlin Multiplatform and also defines shared Android UI, navigation, networking, geo, storage, and base ViewModel utilities.
+- `modules/pages`, `modules/prosemirror`, and `modules/medialibrary` support CMS and rich-content rendering used by festival features.
+
+## Kotlin And Android Patterns
+
+- Check the touched module's `build.gradle.kts` before choosing Java/Kotlin targets. Some modules are Java 11, while newer festival modules are Java 17.
+- Prefer existing Hilt patterns with `@Module`, `@InstallIn`, `@Provides`, and `@Binds`.
+- Keep Room schema and KSP setup consistent with existing module configuration. Do not move schema directories.
+- ViewModels that use `BaseViewModel` should keep the existing intent/partial-state/event pattern:
+  - `UiState` is `Parcelable` where the base class requires it.
+  - intents map to flows of partial state.
+  - reducers are pure state transformations.
+  - one-shot navigation or effects go through event flows/channels.
+- Compose routes should collect state with lifecycle-aware APIs already used in the module, such as `collectAsStateWithLifecycle`.
+- Put user-facing Android strings in resources. Update German resources when changing visible copy that already has German coverage.
+
+## Testing
+
+- Use JUnit5 in modules that apply the JUnit5 plugin; existing tests often use `org.junit.jupiter.api.Test` plus `kotlin.test` assertions.
+- Prefer focused tests for pure mappers, filters, reducers, and use cases.
+- For a touched module, run `./gradlew :modules:<module>:testDebugUnitTest`.
+- For compile-sensitive changes, also run `./gradlew :modules:<module>:assembleDebug`.
+- For `modules/core` KMP changes, consider `./gradlew :modules:core:allTests` or a targeted iOS simulator test only if the changed code affects non-Android source sets.
+- For UI/runtime changes in modules consumed by app shells, also build the relevant app and smoke test it with Mobile MCP.
+
+## Do Not
+
+- Do not refactor package structure across modules as part of a narrow feature change.
+- Do not change Gradle plugin versions or version catalog entries unless dependency work is explicitly requested.
+- Do not run `lintFix`, `detektBaseline`, or other rewriting/baseline tasks unless asked.

--- a/moers-android/AGENTS.md
+++ b/moers-android/AGENTS.md
@@ -1,0 +1,41 @@
+# Mein Moers Android App Instructions
+
+This is the city Android application module.
+
+## App Facts
+
+- Module: `:moers-android`
+- Package/application ID: `com.lambdadigamma.moers`
+- Namespace: `com.lambdadigamma.moers`
+- Main source package: `moers-android/src/main/java/com/lambdadigamma/moers`
+- Main activity: `com.lambdadigamma.moers.MainActivity`
+- Uses Compose, Hilt, Room, Retrofit, protobuf/datastore, Google Play services, and shared modules under `modules/`.
+- This app currently uses Java/Kotlin 11 settings in its Gradle file.
+
+## Local Configuration
+
+- `local.properties` may contain `TANKERKOENIG_API_KEY` and SDK/local API values.
+- `moers-android/local.defaults.properties` documents `MOERS_MAPS_API_KEY`.
+- Release signing expects `keystore.properties` and `Keystore.jks`.
+- Do not read or edit local secrets or signing files unless the user explicitly asks.
+
+## Run And Verify
+
+- Build debug: `./gradlew :moers-android:assembleDebug`
+- Install debug: `./gradlew :moers-android:installDebug`
+- Unit tests: `./gradlew :moers-android:testDebugUnitTest`
+- Lint: `./gradlew :moers-android:lintDebug`
+- Fastlane test lane: `cd moers-android && bundle exec fastlane android test`
+
+For UI/runtime changes:
+
+1. Build or install with Gradle.
+2. Use Mobile MCP to list devices dynamically.
+3. Launch `com.lambdadigamma.moers`.
+4. Capture a screenshot and verify the changed flow or screen.
+
+## Release References
+
+Fastlane lanes exist for `increment_version_code`, `increment_version`, `test`, `debug_build`, `deploy_internal`, `deploy_beta`, and `deploy_production`.
+
+Do not run version bump, deploy, Google Play, signing, or upload lanes without explicit approval.

--- a/moers-festival-android/AGENTS.md
+++ b/moers-festival-android/AGENTS.md
@@ -1,0 +1,52 @@
+# Moers Festival Android App Instructions
+
+This is the festival Android application module. The local `README.md` still contains generic starter-project text; do not rely on it for current app behavior.
+
+## App Facts
+
+- Module: `:moers-festival-android`
+- Package/application ID: `com.lambdadigamma.moersfestival`
+- Namespace: `com.lambdadigamma.moersfestival`
+- Main source package: `moers-festival-android/src/main/java/com/lambdadigamma/moersfestival`
+- Main activity: `com.lambdadigamma.moersfestival.MainActivity`
+- Uses Compose Material3, Hilt, Navigation3, Firebase Analytics/Messaging/Crashlytics, Maps, Ktor/Retrofit, Room, and festival modules under `modules/`.
+- This app uses Java/Kotlin 17 settings in its Gradle file.
+
+## Architecture Notes
+
+- `App.kt` owns onboarding, notification setup state, and the main `NavDisplay`.
+- `FestivalNavKey` and `FestivalTopLevelBackStack` define the Navigation3 app shell.
+- Top-level tabs are News, Map, Favorites, Timetable, and Info.
+- Deep links and notification intents should resolve into synthetic navigation stacks instead of bypassing the app shell.
+- Keep festival data behavior in feature modules where possible; keep app-module code focused on app shell, setup, notifications, and cross-feature wiring.
+
+## Local Configuration
+
+- `moers-festival-android/local.defaults.properties` documents `FESTIVAL_MAPS_API_KEY`.
+- Firebase and Maps configuration may depend on `google-services.json` and local properties.
+- Release signing expects keystore material and Play configuration.
+- Do not read or edit local secrets, Google service files, Play config, or signing files unless explicitly requested.
+
+## Run And Verify
+
+- Build debug: `./gradlew :moers-festival-android:assembleDebug`
+- Install debug: `./gradlew :moers-festival-android:installDebug`
+- Unit tests: `./gradlew :moers-festival-android:testDebugUnitTest`
+- Lint: `./gradlew :moers-festival-android:lintDebug`
+- Detekt: `./gradlew :moers-festival-android:detekt`
+
+For feature-module changes, also run the targeted module test, for example `./gradlew :modules:festival-events:testDebugUnitTest`.
+
+For UI/runtime changes:
+
+1. Build or install with Gradle.
+2. Use Mobile MCP to list devices dynamically.
+3. Launch `com.lambdadigamma.moersfestival`.
+4. Capture screenshots for the affected screen or navigation flow.
+5. Check both German and English where visible localized text changed.
+
+## Release References
+
+Fastlane lanes exist for `increment_version_code`, `increment_version`, `test`, `debug_build`, `slack_apk_build`, `deploy_internal`, `deploy_beta`, and `deploy_production`.
+
+Do not run version bump, deploy, Slack upload, Google Play, signing, or release lanes without explicit approval.


### PR DESCRIPTION
## Summary
- add repo-wide AGENTS.md guidance for AI coding agents
- document Android, iOS, module, workflow, and marketing project instructions in nested AGENTS.md files
- capture safe validation, secrets, release, and Mobile MCP policies

## Testing
- read each new AGENTS.md file after creation
- find . -name AGENTS.md -print
- git status --short -- AGENTS.md .github/AGENTS.md modules/AGENTS.md moers-android/AGENTS.md moers-festival-android/AGENTS.md ios/AGENTS.md ios/CityOS/AGENTS.md 'ios/moers festival/AGENTS.md' marketing/AGENTS.md

No app build run; documentation-only change.